### PR TITLE
fix(ci): pin Node 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Astro 6's CLI forks a Node process; runner's default Node is 20 and
+      # Astro requires >=22.12.0. Set this up BEFORE Bun so `node` in PATH
+      # points at 22 when `astro build` runs.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
The previous run failed because Astro 6 requires Node >=22.12.0 but the GitHub runner defaults to Node 20. Bun's runtime doesn't help here — the astro CLI has a node shebang, so it forks a Node process that uses whatever node is in PATH.

Also sets registry-url so setup-node configures .npmrc for the public registry — redundant with changesets defaults, but makes the publish step more robust.