### PR TITLE
Upgrade emdash 0.6

### DIFF
--- a/.changeset/upgrade-emdash-0.6.md
+++ b/.changeset/upgrade-emdash-0.6.md
@@ -1,0 +1,11 @@
+---
+"@dashcommerce/core": patch
+"@dashcommerce/starter": minor
+---
+
+Upgrade to emdash 0.6.0.
+
+- `@dashcommerce/core`: widen `emdash` peer range to `>=0.5.0 <0.7.0`. Bump the bundled devDeps (`emdash`, `@emdash-cms/admin`) to `^0.6.0` so the package builds against current types. No public API changes.
+- `@dashcommerce/starter`: bump `emdash` and `@emdash-cms/cloudflare` to `^0.6.0`. 0.6's [release fix for `syncSearchState` FTS-during-field-creation](https://github.com/emdash-cms/emdash/pull/595) eliminates the partial-DDL issue that was truncating collection schemas on Cloudflare D1 setup and throwing mid-seed on Postgres. Storefront surfaced zero typecheck errors on the upgrade — no porting required.
+
+Stripe webhook body-clone patch regenerated for 0.6 (`patches/emdash@0.6.0.patch`) since the upstream `request.clone().json()` fix still isn't in place.

--- a/bun.lock
+++ b/bun.lock
@@ -18,19 +18,19 @@
         "dashcommerce-merge-seed": "./dist/cli/merge-seed.js",
       },
       "devDependencies": {
-        "@emdash-cms/admin": "0.5.0",
+        "@emdash-cms/admin": "^0.6.0",
         "@stripe/react-stripe-js": "^3.0.0",
         "@stripe/stripe-js": "^5.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "emdash": "^0.5.0",
+        "emdash": "^0.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tsdown": "^0.20.0",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "emdash": ">=0.4.0 <0.6.0",
+        "emdash": ">=0.5.0 <0.7.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
       },
@@ -66,11 +66,11 @@
         "@astrojs/react": "^5.0.0",
         "@astrojs/sitemap": "^3.4.0",
         "@dashcommerce/core": "workspace:*",
-        "@emdash-cms/cloudflare": "^0.5.0",
+        "@emdash-cms/cloudflare": "^0.6.0",
         "@stripe/react-stripe-js": "^6.0.0",
         "@stripe/stripe-js": "^9.0.0",
         "astro": "^6.0.0",
-        "emdash": "^0.5.0",
+        "emdash": "^0.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -86,7 +86,7 @@
     },
   },
   "patchedDependencies": {
-    "emdash@0.5.0": "patches/emdash@0.5.0.patch",
+    "emdash@0.6.0": "patches/emdash@0.6.0.patch",
   },
   "packages": {
     "@astrojs/check": ["@astrojs/check@0.9.8", "", { "dependencies": { "@astrojs/language-server": "^2.16.5", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw=="],
@@ -259,15 +259,15 @@
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
-    "@emdash-cms/admin": ["@emdash-cms/admin@0.5.0", "", { "dependencies": { "@cloudflare/kumo": "^1.16.0", "@dnd-kit/core": "^6.3.1", "@dnd-kit/sortable": "^10.0.0", "@dnd-kit/utilities": "^3.2.2", "@emdash-cms/blocks": "0.5.0", "@floating-ui/react": "^0.27.16", "@lingui/core": "^5.9.4", "@lingui/react": "^5.9.4", "@phosphor-icons/react": "^2.1.10", "@tanstack/react-query": "5.90.21", "@tanstack/react-router": "1.163.2", "@tiptap/core": "^3.20.0", "@tiptap/extension-character-count": "^3.20.0", "@tiptap/extension-drag-handle": "^3.20.0", "@tiptap/extension-drag-handle-react": "^3.20.0", "@tiptap/extension-dropcursor": "^3.20.0", "@tiptap/extension-focus": "^3.20.0", "@tiptap/extension-link": "^3.20.0", "@tiptap/extension-node-range": "^3.20.0", "@tiptap/extension-placeholder": "^3.20.0", "@tiptap/extension-text-align": "^3.20.0", "@tiptap/extension-typography": "^3.20.0", "@tiptap/extension-underline": "^3.20.0", "@tiptap/pm": "^3.20.0", "@tiptap/react": "^3.20.0", "@tiptap/starter-kit": "^3.20.0", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "dompurify": "^3.3.2", "marked": "^17.0.3", "react": "19.2.4", "react-dom": "19.2.4", "react-hotkeys-hook": "^5.2.4", "tailwind-merge": "^3.3.0" } }, "sha512-iv5x2E9MmAg+EAxr+y8qt2tIqsbBI2cFT3PuIqrLpfnC1V0DZ6U5fRkjbHPt7fUUJf4LHa5fZoKSbzFifmn6Jg=="],
+    "@emdash-cms/admin": ["@emdash-cms/admin@0.6.0", "", { "dependencies": { "@cloudflare/kumo": "^1.16.0", "@dnd-kit/core": "^6.3.1", "@dnd-kit/sortable": "^10.0.0", "@dnd-kit/utilities": "^3.2.2", "@emdash-cms/blocks": "0.6.0", "@floating-ui/react": "^0.27.16", "@lingui/core": "^5.9.4", "@lingui/react": "^5.9.4", "@phosphor-icons/react": "^2.1.10", "@tanstack/react-query": "5.90.21", "@tanstack/react-router": "1.163.2", "@tiptap/core": "^3.20.0", "@tiptap/extension-character-count": "^3.20.0", "@tiptap/extension-drag-handle": "^3.20.0", "@tiptap/extension-drag-handle-react": "^3.20.0", "@tiptap/extension-dropcursor": "^3.20.0", "@tiptap/extension-focus": "^3.20.0", "@tiptap/extension-link": "^3.20.0", "@tiptap/extension-node-range": "^3.20.0", "@tiptap/extension-placeholder": "^3.20.0", "@tiptap/extension-text-align": "^3.20.0", "@tiptap/extension-typography": "^3.20.0", "@tiptap/extension-underline": "^3.20.0", "@tiptap/pm": "^3.20.0", "@tiptap/react": "^3.20.0", "@tiptap/starter-kit": "^3.20.0", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "dompurify": "^3.3.2", "marked": "^17.0.3", "react": "19.2.4", "react-dom": "19.2.4", "react-hotkeys-hook": "^5.2.4", "tailwind-merge": "^3.3.0" } }, "sha512-RH3HQ8ZovTrKA6l3GvGhp1xifdNxINOUV2ohsVa43dbSLRL+h5ojExCOCQ/g7YoUAYg11F3jjzdDOZxnlOcxcA=="],
 
-    "@emdash-cms/auth": ["@emdash-cms/auth@0.5.0", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "@oslojs/webauthn": "^1.0.0", "ulidx": "^2.4.1", "zod": "^4.3.5" }, "peerDependencies": { "astro": ">=6.0.0-beta.0", "kysely": "^0.27.0" }, "optionalPeers": ["kysely"] }, "sha512-rHv/RZtYB2hjblKRbI+mqEqG0k/qGrhacqdXN01TqPcmA5i5UXBkZ1HIzN9ktrI6nA7fbJTmBXGehnK2BH1/rg=="],
+    "@emdash-cms/auth": ["@emdash-cms/auth@0.6.0", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "@oslojs/webauthn": "^1.0.0", "ulidx": "^2.4.1", "zod": "^4.3.5" }, "peerDependencies": { "astro": ">=6.0.0-beta.0", "kysely": "^0.27.0" }, "optionalPeers": ["kysely"] }, "sha512-1ikvF2jYifAMvAIn5ulS8ljnl5eDy3qNKZoVIfGaqtTKQqxtpXcVBH4AY6W7ssebrei7Kpyz/IfRRsxLQZRSOw=="],
 
-    "@emdash-cms/blocks": ["@emdash-cms/blocks@0.5.0", "", { "dependencies": { "@cloudflare/kumo": "^1.10.0", "@phosphor-icons/react": "^2.1.10", "clsx": "^2.1.1", "echarts": "^6.0.0", "tailwind-merge": "^3.3.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-vBuPNuaND1eWFDek4rSkKBXiUyTYxX+8ng+nm3N/GLUYyrb41jbfJolsLp0H85mYoVu1LDP0f/jnxfRNRROP5g=="],
+    "@emdash-cms/blocks": ["@emdash-cms/blocks@0.6.0", "", { "dependencies": { "@cloudflare/kumo": "^1.10.0", "@phosphor-icons/react": "^2.1.10", "clsx": "^2.1.1", "echarts": "^6.0.0", "tailwind-merge": "^3.3.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-Sh9Iy180+wexCkoyz12EEQMfdae3U8+sLY/Kgqvi54ZpplSibsWbwQ/ASnI/ONZ10uo4Vxy0zY1Hj/PEJ/09ww=="],
 
-    "@emdash-cms/cloudflare": ["@emdash-cms/cloudflare@0.5.0", "", { "dependencies": { "emdash": "0.5.0", "jose": "^6.1.3", "kysely-d1": "^0.4.0", "ulidx": "^2.4.1" }, "peerDependencies": { "@cloudflare/workers-types": ">=4.0.0", "astro": ">=6.0.0-beta.0", "kysely": ">=0.27.0" } }, "sha512-q9AER1rnnwOheAsu1u7F7KeTAIgeZyzRq1iAQQhEQXyKcS/9JkXZw4Q/4FLvVcsa7q9avZexnplFFgDF/WJpIg=="],
+    "@emdash-cms/cloudflare": ["@emdash-cms/cloudflare@0.6.0", "", { "dependencies": { "emdash": "0.6.0", "jose": "^6.1.3", "kysely-d1": "^0.4.0", "ulidx": "^2.4.1" }, "peerDependencies": { "@cloudflare/workers-types": ">=4.0.0", "astro": ">=6.0.0-beta.0", "kysely": ">=0.27.0" } }, "sha512-UWIyaQ4pkDZHhakkxIEFqK0JkeBNoIEhExs1hGtXMoqbd2qd4IIvmNxLOUFZZRewc7yLF6TUCla3BppJGzVP8A=="],
 
-    "@emdash-cms/gutenberg-to-portable-text": ["@emdash-cms/gutenberg-to-portable-text@0.5.0", "", { "dependencies": { "@wordpress/block-serialization-default-parser": "^5.13.0", "parse5": "^7.2.1" } }, "sha512-lzivrsa1WVr8DqbBlID2Umg5bCIneai8NdtpHdmDnkg/uCZuCXH4rpcHlGmCKgqrDUHjlPv4cqNORlKOVaJ3pQ=="],
+    "@emdash-cms/gutenberg-to-portable-text": ["@emdash-cms/gutenberg-to-portable-text@0.6.0", "", { "dependencies": { "@wordpress/block-serialization-default-parser": "^5.13.0", "parse5": "^7.2.1" } }, "sha512-8Mp4+0joY59Jd8U5pzyapRiGZaSYPy1z+7JIeJX3t2a6pcP6cJMPfbSHx5ObChP0pDYWR68DcdPnWGrOcUsRNw=="],
 
     "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
 
@@ -973,7 +973,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.340", "", {}, "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA=="],
 
-    "emdash": ["emdash@0.5.0", "", { "dependencies": { "@emdash-cms/admin": "0.5.0", "@emdash-cms/auth": "0.5.0", "@emdash-cms/gutenberg-to-portable-text": "0.5.0", "@floating-ui/react": "^0.27.16", "@modelcontextprotocol/sdk": "^1.26.0", "@portabletext/toolkit": "^5.0.1", "@tiptap/core": "^3.20.0", "@tiptap/extension-focus": "^3.20.0", "@tiptap/extension-image": "^3.20.0", "@tiptap/extension-link": "^3.20.0", "@tiptap/extension-placeholder": "^3.20.0", "@tiptap/extension-text-align": "^3.20.0", "@tiptap/extension-typography": "^3.20.0", "@tiptap/extension-underline": "^3.20.0", "@tiptap/react": "^3.20.0", "@tiptap/starter-kit": "^3.20.0", "@tiptap/suggestion": "^3.20.0", "@unpic/placeholder": "^0.1.2", "arctic": "^3.7.0", "astro-portabletext": "^0.11.0", "better-sqlite3": "^12.8.0", "blurhash": "^2.0.5", "citty": "^0.1.6", "consola": "^3.4.2", "croner": "^10.0.1", "image-size": "^2.0.2", "jose": "^6.1.3", "jpeg-js": "^0.4.4", "kysely": "^0.27.0", "mime": "^4.1.0", "modern-tar": "^0.7.5", "picocolors": "^1.1.1", "sanitize-html": "^2.17.1", "sax": "^1.4.1", "ulidx": "^2.4.1", "upng-js": "^2.1.0", "zod": "^4.3.5" }, "optionalDependencies": { "@libsql/kysely-libsql": "^0.4.0", "pg": "^8.0.0" }, "peerDependencies": { "@astrojs/react": ">=5.0.0-beta.0", "@tanstack/react-query": ">=5.0.0", "@tanstack/react-router": ">=1.100.0", "astro": ">=6.0.0-beta.0", "react": ">=18.0.0", "react-dom": ">=18.0.0" }, "bin": { "emdash": "dist/cli/index.mjs", "em": "dist/cli/index.mjs" } }, "sha512-7tUIlMEYdSJ6FmmW0DbnhiGC77u593hitvmX3H7jAywbZk1/aobicg3YnswzxhzNHsHU4QHLoTDadwQVZwrthA=="],
+    "emdash": ["emdash@0.6.0", "", { "dependencies": { "@emdash-cms/admin": "0.6.0", "@emdash-cms/auth": "0.6.0", "@emdash-cms/gutenberg-to-portable-text": "0.6.0", "@floating-ui/react": "^0.27.16", "@modelcontextprotocol/sdk": "^1.26.0", "@portabletext/toolkit": "^5.0.1", "@tiptap/core": "^3.20.0", "@tiptap/extension-focus": "^3.20.0", "@tiptap/extension-image": "^3.20.0", "@tiptap/extension-link": "^3.20.0", "@tiptap/extension-placeholder": "^3.20.0", "@tiptap/extension-text-align": "^3.20.0", "@tiptap/extension-typography": "^3.20.0", "@tiptap/extension-underline": "^3.20.0", "@tiptap/react": "^3.20.0", "@tiptap/starter-kit": "^3.20.0", "@tiptap/suggestion": "^3.20.0", "@unpic/placeholder": "^0.1.2", "arctic": "^3.7.0", "astro-portabletext": "^0.11.0", "better-sqlite3": "^12.8.0", "blurhash": "^2.0.5", "citty": "^0.1.6", "consola": "^3.4.2", "croner": "^10.0.1", "image-size": "^2.0.2", "jose": "^6.1.3", "jpeg-js": "^0.4.4", "kysely": "^0.27.0", "mime": "^4.1.0", "modern-tar": "^0.7.5", "picocolors": "^1.1.1", "sanitize-html": "^2.17.1", "sax": "^1.4.1", "ulidx": "^2.4.1", "upng-js": "^2.1.0", "zod": "^4.3.5" }, "optionalDependencies": { "@libsql/kysely-libsql": "^0.4.0", "pg": "^8.0.0" }, "peerDependencies": { "@astrojs/react": ">=5.0.0-beta.0", "@tanstack/react-query": ">=5.0.0", "@tanstack/react-router": ">=1.100.0", "astro": ">=6.0.0-beta.0", "react": ">=18.0.0", "react-dom": ">=18.0.0" }, "bin": { "emdash": "dist/cli/index.mjs", "em": "dist/cli/index.mjs" } }, "sha512-lc9AinEPoJ9xD1dCN5TuyKL3PtMLDL1jUTncwfFQNoRlUvq5UGo5djrrWWpqav8iEwVucH+GkgHqVB4Tk13s8A=="],
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "bun": ">=1.1.0"
   },
   "patchedDependencies": {
-    "emdash@0.5.0": "patches/emdash@0.5.0.patch"
+    "emdash@0.6.0": "patches/emdash@0.6.0.patch"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "test": "bun test"
   },
   "peerDependencies": {
-    "emdash": ">=0.4.0 <0.6.0",
+    "emdash": ">=0.5.0 <0.7.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
@@ -78,12 +78,12 @@
     }
   },
   "devDependencies": {
-    "@emdash-cms/admin": "0.5.0",
+    "@emdash-cms/admin": "^0.6.0",
     "@stripe/react-stripe-js": "^3.0.0",
     "@stripe/stripe-js": "^5.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "emdash": "^0.5.0",
+    "emdash": "^0.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tsdown": "^0.20.0",

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -31,11 +31,11 @@
 		"@astrojs/react": "^5.0.0",
 		"@astrojs/sitemap": "^3.4.0",
 		"@dashcommerce/core": "workspace:*",
-		"@emdash-cms/cloudflare": "^0.5.0",
+		"@emdash-cms/cloudflare": "^0.6.0",
 		"@stripe/react-stripe-js": "^6.0.0",
 		"@stripe/stripe-js": "^9.0.0",
 		"astro": "^6.0.0",
-		"emdash": "^0.5.0",
+		"emdash": "^0.6.0",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"
 	},

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -16,7 +16,7 @@
 		"cf:deploy": "bun run build:cf && wrangler deploy --config dist/server/wrangler.json",
 		"cf:dev": "bun run build:cf && wrangler dev --config dist/server/wrangler.json",
 		"cf:d1:create": "wrangler d1 create dashcommerce-demo",
-		"cf:d1:seed": "bun run bootstrap && sqlite3 data.db .dump | grep -v -E '^(PRAGMA|BEGIN|COMMIT|CREATE TABLE sqlite_)' > .emdash/d1-seed.sql && wrangler d1 execute dashcommerce-demo --remote --file=.emdash/d1-seed.sql",
+		"cf:d1:seed": "node scripts/cf-d1-seed.mjs",
 		"typecheck": "astro check"
 	},
 	"emdash": {

--- a/packages/starter/scripts/cf-d1-dump.mjs
+++ b/packages/starter/scripts/cf-d1-dump.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Produce a D1-safe SQL dump from local data.db.
+ *
+ * Why a dedicated script (not just sqlite3 .dump | grep):
+ * - SQLite's `.dump` represents FTS5 virtual tables as INSERT INTO sqlite_schema(...).
+ *   D1 rejects any write to sqlite_schema/sqlite_master with "table sqlite_master
+ *   may not be modified", so those statements must go.
+ * - FTS5 triggers that live on the host tables (e.g. _emdash_fts_products_insert)
+ *   also write into the virtual tables' shadow storage. Once we drop the FTS5
+ *   tables, those triggers become broken — cleanest to drop them too.
+ * - We do all of this on a *copy* of data.db so local dev + search keep working.
+ *
+ * Trade-off: full-text search won't work on the D1 deploy until emdash's D1
+ * adapter learns to materialize FTS5 indexes itself. Everything else (products,
+ * checkout, admin, blog) lands intact.
+ */
+
+import {
+	copyFileSync,
+	existsSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SRC = "data.db";
+const COPY = "/tmp/dashcommerce-d1-export.db";
+const OUT = ".emdash/d1-seed.sql";
+
+if (!existsSync(SRC)) {
+	console.error(
+		`[cf-d1-dump] ${SRC} not found. Run \`bun run bootstrap\` first.`,
+	);
+	process.exit(1);
+}
+
+if (existsSync(COPY)) unlinkSync(COPY);
+copyFileSync(SRC, COPY);
+
+function sqlite(cmd) {
+	return execFileSync("sqlite3", [COPY, cmd]).toString();
+}
+
+const ftsTables = sqlite(
+	"SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '_emdash_fts%' ORDER BY name",
+)
+	.trim()
+	.split(/\r?\n/)
+	.filter(Boolean);
+
+for (const t of ftsTables) {
+	sqlite(`DROP TABLE IF EXISTS "${t}"`);
+}
+
+const ftsTriggers = sqlite(
+	"SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE '_emdash_fts%' ORDER BY name",
+)
+	.trim()
+	.split(/\r?\n/)
+	.filter(Boolean);
+
+for (const t of ftsTriggers) {
+	sqlite(`DROP TRIGGER IF EXISTS "${t}"`);
+}
+
+const raw = execFileSync("sqlite3", [COPY, ".dump"]).toString();
+
+// D1 rejects: header PRAGMAs, explicit transactions, CREATE TABLE on sqlite_*,
+// any INSERT into sqlite_schema (the dump's representation of virtual tables).
+const safe = raw
+	.split("\n")
+	.filter((line) => !/^(PRAGMA|BEGIN|COMMIT|ROLLBACK)\b/.test(line))
+	.filter((line) => !/^CREATE TABLE\s+"?sqlite_/.test(line))
+	.filter((line) => !/^INSERT INTO\s+"?sqlite_/.test(line))
+	.join("\n");
+
+writeFileSync(OUT, safe);
+unlinkSync(COPY);
+
+console.log(
+	`[cf-d1-dump] wrote ${OUT} — stripped ${ftsTables.length} FTS5 tables, ${ftsTriggers.length} FTS5 triggers`,
+);

--- a/packages/starter/scripts/cf-d1-seed.mjs
+++ b/packages/starter/scripts/cf-d1-seed.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Orchestrate the full "seed D1 from local SQLite" flow without requiring
+ * the deployer to hand-edit wrangler.jsonc.
+ *
+ * Flow:
+ *   1. Bootstrap local SQLite (schema + seed + demo catalog)
+ *   2. Produce a D1-safe SQL dump (strips FTS5 + sqlite_schema writes)
+ *   3. Temporarily patch wrangler.jsonc's placeholder with the deployer's
+ *      real database_id (from CF_D1_DATABASE_ID env var), run `wrangler d1`
+ *      commands, then restore the template.
+ *   4. Drop existing tables on D1 (avoids PK collisions on rerun)
+ *   5. Import the dump
+ *
+ * Usage:
+ *   CF_D1_DATABASE_ID=<uuid> bun run cf:d1:seed
+ *
+ * The template wrangler.jsonc stays committed with the REPLACE_AFTER… placeholder
+ * so the starter remains multi-tenant — each deployer brings their own ids.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+	copyFileSync,
+	existsSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+
+const WRANGLER = "wrangler.jsonc";
+const BACKUP = "wrangler.jsonc.bak";
+const PLACEHOLDER = "REPLACE_AFTER_WRANGLER_D1_CREATE";
+const DB_NAME = "dashcommerce-demo";
+
+const dbId = process.env.CF_D1_DATABASE_ID;
+if (!dbId) {
+	console.error(`
+[cf-d1-seed] CF_D1_DATABASE_ID env var is required.
+
+Create a D1 database and export its id:
+  wrangler d1 create ${DB_NAME}
+  export CF_D1_DATABASE_ID=<uuid-from-output>
+  bun run cf:d1:seed
+`);
+	process.exit(1);
+}
+
+function run(cmd, args, options = {}) {
+	const result = spawnSync(cmd, args, {
+		stdio: "inherit",
+		...options,
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			`${cmd} ${args.join(" ")} exited with status ${result.status}`,
+		);
+	}
+	return result;
+}
+
+function capture(cmd, args) {
+	const result = spawnSync(cmd, args, { stdio: ["ignore", "pipe", "inherit"] });
+	if (result.status !== 0) {
+		throw new Error(
+			`${cmd} ${args.join(" ")} exited with status ${result.status}`,
+		);
+	}
+	return result.stdout.toString();
+}
+
+function restoreWrangler() {
+	if (existsSync(BACKUP)) {
+		copyFileSync(BACKUP, WRANGLER);
+		unlinkSync(BACKUP);
+	}
+}
+
+process.on("SIGINT", () => {
+	restoreWrangler();
+	process.exit(130);
+});
+
+try {
+	console.log("→ Bootstrapping local SQLite...");
+	run("bun", ["run", "bootstrap"]);
+
+	console.log("→ Generating D1-safe SQL dump...");
+	run("node", ["scripts/cf-d1-dump.mjs"]);
+
+	console.log("→ Patching wrangler.jsonc with real D1 id (temporary)...");
+	copyFileSync(WRANGLER, BACKUP);
+	const contents = readFileSync(WRANGLER, "utf8");
+	if (!contents.includes(PLACEHOLDER)) {
+		console.warn(
+			`[cf-d1-seed] ${WRANGLER} doesn't contain the expected placeholder "${PLACEHOLDER}". Carrying on with the file as-is.`,
+		);
+	}
+	writeFileSync(WRANGLER, contents.replaceAll(PLACEHOLDER, dbId));
+
+	console.log("→ Dropping existing tables on D1...");
+	const listJson = capture("wrangler", [
+		"d1",
+		"execute",
+		DB_NAME,
+		"--remote",
+		"--json",
+		"--command",
+		"SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%'",
+	]);
+	const tables = Array.from(listJson.matchAll(/"name"\s*:\s*"([^"]+)"/g)).map(
+		(m) => m[1],
+	);
+	for (const t of tables) {
+		run("wrangler", [
+			"d1",
+			"execute",
+			DB_NAME,
+			"--remote",
+			"--command",
+			`DROP TABLE IF EXISTS "${t}"`,
+		]);
+	}
+
+	console.log("→ Applying dump to D1...");
+	run("wrangler", [
+		"d1",
+		"execute",
+		DB_NAME,
+		"--remote",
+		"--file",
+		".emdash/d1-seed.sql",
+	]);
+
+	console.log("\n✓ D1 seeded. Tables now live:");
+	run("wrangler", [
+		"d1",
+		"execute",
+		DB_NAME,
+		"--remote",
+		"--command",
+		"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+	]);
+} catch (err) {
+	console.error(`\n[cf-d1-seed] ${err.message}`);
+	process.exitCode = 1;
+} finally {
+	restoreWrangler();
+}

--- a/packages/starter/wrangler.jsonc
+++ b/packages/starter/wrangler.jsonc
@@ -2,8 +2,9 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "dashcommerce-demo",
 	"compatibility_date": "2026-04-01",
-	"compatibility_flags": ["nodejs_compat"],
-
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
 	// `main` and `assets` are intentionally omitted here. @astrojs/cloudflare
 	// v13+ emits a fully-resolved `dist/server/wrangler.json` at build time
 	// that merges these fields with the bindings + vars below. Always deploy
@@ -12,11 +13,9 @@
 	//   wrangler deploy --config dist/server/wrangler.json
 	//
 	// Use `bun run cf:deploy` which handles this automatically.
-
 	"vars": {
 		"SITE_URL": "https://demo.dashcommerce.dev"
 	},
-
 	"d1_databases": [
 		{
 			"binding": "DB",
@@ -24,14 +23,17 @@
 			"database_id": "REPLACE_AFTER_WRANGLER_D1_CREATE"
 		}
 	],
-
 	"r2_buckets": [
 		{
 			"binding": "MEDIA",
 			"bucket_name": "dashcommerce-demo-media"
 		}
+	],
+	"kv_namespaces": [
+		{
+			"binding": "SESSION"
+		}
 	]
-
 	// Secrets (not in this file — set via `wrangler secret put`):
 	//   EMDASH_AUTH_SECRET      — session/token signing (generate with `openssl rand -hex 32`)
 	//   EMDASH_PREVIEW_SECRET   — draft content preview signing

--- a/patches/emdash@0.6.0.patch
+++ b/patches/emdash@0.6.0.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/astro/middleware.mjs b/dist/astro/middleware.mjs
-index f7a3dcb930371a4338c3418fdb767baf4144b42c..3ea00669a085a0fbeba55d948c8fead648a77cff 100644
+index 466f69f8eb08c1f779ebc0f804b73bd0637536b3..d83a6106d7ed6bc50a0318c4fae40fd9dd116848 100644
 --- a/dist/astro/middleware.mjs
 +++ b/dist/astro/middleware.mjs
-@@ -1254,7 +1254,7 @@ var EmDashRuntime = class EmDashRuntime {
+@@ -1401,7 +1401,7 @@ var EmDashRuntime = class EmDashRuntime {
  			const routeKey = path.replace(LEADING_SLASH_PATTERN, "");
  			let body = void 0;
  			try {
@@ -11,7 +11,7 @@ index f7a3dcb930371a4338c3418fdb767baf4144b42c..3ea00669a085a0fbeba55d948c8fead6
  			} catch {}
  			return routeRegistry.invoke(pluginId, routeKey, {
  				request,
-@@ -1387,7 +1387,7 @@ var EmDashRuntime = class EmDashRuntime {
+@@ -1534,7 +1534,7 @@ var EmDashRuntime = class EmDashRuntime {
  		const routeName = path.replace(LEADING_SLASH_PATTERN, "");
  		let body = void 0;
  		try {
@@ -39,10 +39,10 @@ index b295a642565f495ae12215c3c7be7494bc4ba43b..285539036ba344c43726b12fdf8f757c
  };
  
 diff --git a/src/emdash-runtime.ts b/src/emdash-runtime.ts
-index be83a7d5aee97cce76ff5dd775bd978e9e2fdd22..7630ab6809ad2470638de1a459f21897857d4a41 100644
+index dd9192aa624b9da20d36b03e2854547b155ce6a7..f19f37483060b1b8f6295c4f7484638df3f1e96f 100644
 --- a/src/emdash-runtime.ts
 +++ b/src/emdash-runtime.ts
-@@ -1869,7 +1869,7 @@ export class EmDashRuntime {
+@@ -2087,7 +2087,7 @@ export class EmDashRuntime {
  
  			let body: unknown = undefined;
  			try {
@@ -51,7 +51,7 @@ index be83a7d5aee97cce76ff5dd775bd978e9e2fdd22..7630ab6809ad2470638de1a459f21897
  			} catch {
  				// No body or not JSON
  			}
-@@ -2096,7 +2096,7 @@ export class EmDashRuntime {
+@@ -2314,7 +2314,7 @@ export class EmDashRuntime {
  
  		let body: unknown = undefined;
  		try {


### PR DESCRIPTION
## Summary

- Bumps `emdash` + `@emdash-cms/cloudflare` to `^0.6.0`
- Widens core's `emdash` peer range to `>=0.5.0 <0.7.0`
- Regenerates the Stripe webhook body-clone patch for 0.6
- Changeset: core patch, starter minor
