### PR TITLE
fix(admin): guard dashboard widgets against incomplete API payloads

### DIFF
--- a/packages/core/src/admin/widgets/FailedSubscriptions.tsx
+++ b/packages/core/src/admin/widgets/FailedSubscriptions.tsx
@@ -18,7 +18,7 @@ export function FailedSubscriptions() {
 
 	if (!data) return <Loading />;
 
-	if (data.count === 0) {
+	if ((data.count ?? 0) === 0) {
 		return <p style={{ margin: 0 }}>All subscriptions current ✓</p>;
 	}
 
@@ -28,7 +28,7 @@ export function FailedSubscriptions() {
 				{data.count} past-due
 			</div>
 			<ul style={{ margin: 0, paddingLeft: 18 }}>
-				{data.items.map((s) => (
+				{(data.items ?? []).map((s) => (
 					<li key={s.id}>
 						<MoneyDisplay value={s.unitAmount} /> / {s.intervalCount}{" "}
 						{s.interval}

--- a/packages/core/src/admin/widgets/LowStockAlerts.tsx
+++ b/packages/core/src/admin/widgets/LowStockAlerts.tsx
@@ -15,7 +15,7 @@ export function LowStockAlerts() {
 
 	useEffect(() => {
 		api.get<{ items: Row[] }>("admin/widgets/low-stock-alerts").then((r) =>
-			setRows(r.items),
+			setRows(r.items ?? []),
 		);
 	}, [api]);
 

--- a/packages/core/src/admin/widgets/PendingReviews.tsx
+++ b/packages/core/src/admin/widgets/PendingReviews.tsx
@@ -8,7 +8,7 @@ export function PendingReviews() {
 	useEffect(() => {
 		api
 			.get<{ count: number }>("admin/widgets/pending-reviews")
-			.then((r) => setCount(r.count));
+			.then((r) => setCount(r.count ?? 0));
 	}, [api]);
 
 	if (count === null) return <Loading />;

--- a/packages/core/src/admin/widgets/RecentOrders.tsx
+++ b/packages/core/src/admin/widgets/RecentOrders.tsx
@@ -19,7 +19,7 @@ export function RecentOrders() {
 
 	useEffect(() => {
 		api.get<{ items: Row[] }>("admin/widgets/recent-orders").then((r) =>
-			setRows(r.items),
+			setRows(r.items ?? []),
 		);
 	}, [api]);
 

--- a/packages/core/src/admin/widgets/RevenueSnapshot.tsx
+++ b/packages/core/src/admin/widgets/RevenueSnapshot.tsx
@@ -22,9 +22,9 @@ export function RevenueSnapshot() {
 				<div>
 					<div style={{ fontSize: "0.8em", color: "#666" }}>Last 7 days</div>
 					<div style={{ fontSize: "1.4em", fontWeight: 700 }}>
-						{Object.entries(data.sevenDay).length === 0
+						{Object.entries(data.sevenDay ?? {}).length === 0
 							? "—"
-							: Object.entries(data.sevenDay)
+							: Object.entries(data.sevenDay ?? {})
 									.map(([c, v]) => `${c} ${(v as number) / 100}`)
 									.join(" · ")}
 					</div>
@@ -32,9 +32,9 @@ export function RevenueSnapshot() {
 				<div>
 					<div style={{ fontSize: "0.8em", color: "#666" }}>Last 30 days</div>
 					<div style={{ fontSize: "1.4em", fontWeight: 700 }}>
-						{Object.entries(data.thirtyDay).length === 0
+						{Object.entries(data.thirtyDay ?? {}).length === 0
 							? "—"
-							: Object.entries(data.thirtyDay)
+							: Object.entries(data.thirtyDay ?? {})
 									.map(([c, v]) => `${c} ${(v as number) / 100}`)
 									.join(" · ")}
 					</div>


### PR DESCRIPTION
Fixes #19

## Summary

- On a fresh/empty store, the admin widgets' plugin API responses come back with their "empty" fields (empty object/array, zero count) missing entirely rather than present-but-empty — e.g. `admin/widgets/revenue-snapshot` returns `{"data":{}}` instead of `{"data":{"sevenDay":{},"thirtyDay":{}}}`. See #19 for the full repro and what I could trace of the root cause.
- None of the five dashboard widgets guarded against this, so whichever rendered first threw synchronously and, since the error boundary wraps the whole admin app, white-screened the entire `/_emdash/admin` dashboard on every brand new install (zero orders yet).
- This PR defaults each field to its empty value (`{}` / `[]` / `0`) in `RevenueSnapshot`, `LowStockAlerts`, `RecentOrders`, `PendingReviews`, and `FailedSubscriptions` so they render their normal empty state instead of crashing.

This is a defensive client-side fix — it doesn't address wherever the payload actually gets thinned out (likely outside this repo, in `emdash` itself), but it makes the dashboard resilient regardless of where that turns out to live, and widgets probably shouldn't assume every field is always present either way.

## Test plan

- [x] `bun run typecheck` in `packages/core` — clean
- [x] `bunx biome lint packages/core/src/admin/widgets` — clean
- [x] Reproduced the crash on a freshly seeded local store (`bun run bootstrap`) and confirmed each of the five widgets renders its empty state after this change, verified against a production build (`astro build` + `astro preview`, not dev mode) of a DashCommerce starter site